### PR TITLE
Add deprecation notice in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,8 @@ ssqs
 ------
 Provides a super simple consumer for Amazon SQS.
 
+### **_DEPRECATED_**
+
+**This repository is to be considered _DEPRECATED_. No code should be added to this repository**
+
 [![GoDoc](https://godoc.org/github.com/LloydGriffiths/ssqs?status.svg)](https://godoc.org/github.com/LloydGriffiths/ssqs)


### PR DESCRIPTION


dp-deployer was using the previous version of master branch that was not tagged with a version.

This made maintenance very problematic from the point of view of trying to understand what branch of the ssqs was being used.

dp-deployer has now had the specific version of this lib that it was using pulled into its repo.

No other repo uses this, so it is being marked as deprecated.
